### PR TITLE
Update modbus.yaml

### DIFF
--- a/modbus.yaml
+++ b/modbus.yaml
@@ -10,8 +10,9 @@
       unique_id: ecodesign_climates_temp_soll
       scan_interval: 10
       slave: 3
-      address: 4
-      input_type: holding
+      address: 8
+      input_type: input
+      scale: 0.1
       max_temp: 62
       min_temp: 5
       precision: 1


### PR DESCRIPTION
modified "EcoDesign Solltemperatur Set" so that it provides the current temperature also. This can then be used on a Thermostat card, which allows the user to view current temperature and set the target temperature.